### PR TITLE
fix(Previdência): ORB-1315 - Ajustando descrição de ENUM - EnumPersonalUpdateIndex

### DIFF
--- a/documentation/source/swagger/parts/schemas/enum/EnumPersonalUpdateIndex.yaml
+++ b/documentation/source/swagger/parts/schemas/enum/EnumPersonalUpdateIndex.yaml
@@ -4,7 +4,7 @@ description: |
     1. IPCA (IBGE)
     2. IGP-M (FGV)
     3. INPC (IBGE)
-    4. NÃO APLICÁVEL
+    4. NÃO APLICA
 maxLength: 13
 enum:
   - IPCA


### PR DESCRIPTION
O QUE?

Alterar o enum da lista do campo “updateIndexes” de NAO_APLICAVEL para NAO_APLICA.

ONDE?

Na API de Previdência em Cobertura e Risco.

Endpoint: GET /risk-coverages