### PR TITLE
feat(Capitalização): ORB-1320

### DIFF
--- a/documentation/source/swagger/parts/schemas/capitalization_bonds_apis/CapitalizationBondsProductPrizeDraw.yaml
+++ b/documentation/source/swagger/parts/schemas/capitalization_bonds_apis/CapitalizationBondsProductPrizeDraw.yaml
@@ -4,7 +4,7 @@ required:
   - quantity
   - prizeMultiplier
   - earlySettlementRaffle
-  - mandatoryDraw
+  - mandatoryContemplation
   - minimumContemplationProbability
 properties:
   timeInterval:


### PR DESCRIPTION
Junto com a Fabrice, identificamos que o campo /mandatoryDraw sofreu alteração para /mandatoryContemplation mas que no yaml ainda houve um “resquício” que fez com que gerasse uma divergência (conforme anexo).

Com isso, será necessário ajuste para evitarmos dúvidas e conflito de entendimento às IFs.

OBS: esta alteração de nomenclatura do campo foi atendida no ORB-759